### PR TITLE
Improve fragment and asset queries

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@puzzle-js/client-lib",
   "main": "dist/index.js",
-  "version": "1.7.1",
+  "version": "1.8.0",
   "author": "<emre.kul@trendyol.com>",
   "license": "MIT",
   "repository": {

--- a/src/core.ts
+++ b/src/core.ts
@@ -203,7 +203,13 @@ export class Core extends Module {
   }
 
   private static getFragmentContainerSelector(fragment: IPageFragmentConfig, partial: string) {
-    return partial === "main" ? `[puzzle-fragment="${fragment.name}"]:not([fragment-partial])` : `[puzzle-fragment="${fragment.name}"][fragment-partial="${partial}"]`;
+    const query =  partial === "main" ? `[puzzle-fragment="${fragment.name}"]:not([fragment-partial])` : `[puzzle-fragment="${fragment.name}"][fragment-partial="${partial}"]`;
+
+    if (fragment.gateway) {
+      return `[puzzle-gateway="${fragment.gateway}"]${query}`;
+    }
+
+    return query;
   }
 
   private static prepareQueryString(fragmentAttributes: Record<string, string>) {

--- a/src/core.ts
+++ b/src/core.ts
@@ -39,7 +39,7 @@ export class Core extends Module {
 
     if (this.isIntersectionObserverSupported()) {
       const asyncFragments = fragments.some(i => i.clientAsync);
-      
+
       if (asyncFragments && Core.__pageConfiguration.intersectionObserverOptions) {
         this.observer = new IntersectionObserver(this.onIntersection.bind(this), Core.__pageConfiguration.intersectionObserverOptions);
       } else if (asyncFragments) {
@@ -62,8 +62,13 @@ export class Core extends Module {
   }
 
   @on(EVENT.ON_FRAGMENT_RENDERED)
-  static loadAssetsOnFragment(fragmentName: string) {
-    const onFragmentRenderAssets = Core.__pageConfiguration.assets.filter(asset => asset.fragment === fragmentName && asset.loadMethod === RESOURCE_LOADING_TYPE.ON_FRAGMENT_RENDER && !asset.preLoaded);
+  static loadAssetsOnFragment(fragmentName: string, containerSelector?: string, replacementContentSelector?: string, gatewayName?: string) {
+    const onFragmentRenderAssets = Core.__pageConfiguration.assets.filter(
+      asset => asset.fragment === fragmentName &&
+        ((gatewayName && asset.gateway) ? gatewayName === asset.gateway : true) &&
+        asset.loadMethod === RESOURCE_LOADING_TYPE.ON_FRAGMENT_RENDER &&
+        !asset.preLoaded
+    );
 
     const assets = Core.createLoadQueue(onFragmentRenderAssets);
 
@@ -74,7 +79,10 @@ export class Core extends Module {
   static pageLoaded() {
     const onFragmentRenderAssets = Core.__pageConfiguration.assets.filter(asset => {
       if (asset.loadMethod === RESOURCE_LOADING_TYPE.ON_PAGE_RENDER && !asset.preLoaded) {
-        const fragment = Core.__pageConfiguration.fragments.find(fragment => fragment.name === asset.fragment);
+        const fragment = Core.__pageConfiguration.fragments.find(
+          _fragment => _fragment.name === asset.fragment &&
+            ((_fragment.gateway && asset.gateway) ? _fragment.gateway === asset.gateway : true)
+        );
         return fragment && fragment.attributes.if !== "false";
       }
       return false;
@@ -176,7 +184,10 @@ export class Core extends Module {
       }
     }
 
-    const fragmentAssets = Core.__pageConfiguration.assets.filter(asset => asset.fragment === fragment.name);
+    const fragmentAssets = Core.__pageConfiguration.assets.filter(
+      asset => asset.fragment === fragment.name &&
+        ((fragment.gateway && asset.gateway) ? fragment.gateway === asset.gateway : true)
+    );
     const assets = Core.createLoadQueue(fragmentAssets, true);
 
     AssetHelper.loadAssetSeries(assets, () => {
@@ -232,7 +243,10 @@ export class Core extends Module {
     const loadList: any = [];
 
     assets.forEach(asset => {
-      const fragment = Core.__pageConfiguration.fragments.find(i => i.name === asset.fragment);
+      const fragment = Core.__pageConfiguration.fragments.find(
+        _fragment => _fragment.name === asset.fragment &&
+          ((_fragment.gateway && asset.gateway) ? _fragment.gateway === asset.gateway : true)
+      );
       if (asyncQueue || (fragment && !fragment.clientAsync)) {
         if (asset.type === RESOURCE_TYPE.JS) {
           if (!asset.preLoaded) {
@@ -293,7 +307,11 @@ export class Core extends Module {
       if (change.isIntersecting) {
         const target = change.target;
         const fragmentName = target.getAttribute('puzzle-fragment');
-        const fragment = Core.__pageConfiguration.fragments.find(i => i.name === fragmentName);
+        const gatewayName = target.getAttribute('puzzle-gateway');
+        const fragment = Core.__pageConfiguration.fragments.find(
+            _fragment => _fragment.name === fragmentName &&
+            ((_fragment.gateway && gatewayName) ? _fragment.gateway === gatewayName : true)
+        );
         if (fragment) {
           this.asyncLoadFragment(fragment);
           observer.unobserve(target);
@@ -302,8 +320,11 @@ export class Core extends Module {
     });
   }
 
-  static renderAsyncFragment(fragmentName: string) {
-    const fragment = this.__pageConfiguration.fragments.find(item => item.name === fragmentName);
+  static renderAsyncFragment(fragmentName: string, gatewayName?: string) {
+    const fragment = this.__pageConfiguration.fragments.find(
+      _fragment => _fragment.name === fragmentName &&
+        ((_fragment.gateway && gatewayName) ? _fragment.gateway === gatewayName : true)
+    );
     if (fragment) {
       const selector = this.getFragmentContainerSelector(fragment, "main");
       const fragmentContainer = window.document.querySelector(selector);

--- a/src/types.ts
+++ b/src/types.ts
@@ -18,6 +18,7 @@ export interface IPageLibAsset {
   link: string;
   preLoaded: boolean;
   defer?: boolean;
+  gateway: string;
 }
 
 export interface ICustomPageAsset {
@@ -29,6 +30,7 @@ export interface ICustomPageAsset {
 
 export interface IPageFragmentConfig {
   name: string;
+  gateway: string;
   chunked: boolean;
   clientAsync: boolean;
   clientAsyncForce: boolean | undefined;

--- a/test/assetHelper.spec.ts
+++ b/test/assetHelper.spec.ts
@@ -35,6 +35,7 @@ describe('Module - Asset Helper', () => {
         // arrange
         const asset: IPageLibAsset = {
             name: faker.lorem.word(),
+            gateway: faker.lorem.word(),
             loadMethod: RESOURCE_LOADING_TYPE.ON_FRAGMENT_RENDER,
             fragment: faker.lorem.word(),
             dependent: [],
@@ -55,6 +56,7 @@ describe('Module - Asset Helper', () => {
         // arrange
         const asset: IPageLibAsset = {
             name: faker.lorem.word(),
+            gateway: faker.lorem.word(),
             loadMethod: RESOURCE_LOADING_TYPE.ON_FRAGMENT_RENDER,
             fragment: faker.lorem.word(),
             dependent: [],
@@ -77,6 +79,7 @@ describe('Module - Asset Helper', () => {
         const assets: IPageLibAsset[] = [
             {
                 name: faker.lorem.word(),
+                gateway: faker.lorem.word(),
                 loadMethod: RESOURCE_LOADING_TYPE.ON_FRAGMENT_RENDER,
                 fragment: faker.lorem.word(),
                 dependent: [],
@@ -107,6 +110,7 @@ describe('Module - Asset Helper', () => {
         const assets: IPageLibAsset[] = [
             {
                 name: faker.lorem.word(),
+                gateway: faker.lorem.word(),
                 loadMethod: RESOURCE_LOADING_TYPE.ON_FRAGMENT_RENDER,
                 fragment: faker.lorem.word(),
                 dependent: [],
@@ -136,6 +140,7 @@ describe('Module - Asset Helper', () => {
         const assets: IPageLibAsset[] = [
             {
                 name: faker.lorem.word(),
+                gateway: faker.lorem.word(),
                 loadMethod: RESOURCE_LOADING_TYPE.ON_FRAGMENT_RENDER,
                 fragment: faker.lorem.word(),
                 dependent: [],
@@ -166,6 +171,7 @@ describe('Module - Asset Helper', () => {
         const assets: IPageLibAsset[] = [
             {
                 name: faker.lorem.word(),
+                gateway: faker.lorem.word(),
                 loadMethod: RESOURCE_LOADING_TYPE.ON_FRAGMENT_RENDER,
                 fragment: faker.lorem.word(),
                 dependent: [],

--- a/test/core.spec.ts
+++ b/test/core.spec.ts
@@ -34,7 +34,7 @@ describe('Module - Core', () => {
     global.IntersectionObserver = Object;
     global.IntersectionObserver.prototype.observe = sandbox.stub();
     global.IntersectionObserver.prototype.unobserve = sandbox.stub();
-   
+
     global.window.IntersectionObserver = Object;
     global.window.IntersectionObserverEntry = {};
     global.window.IntersectionObserverEntry.prototype = { intersectionRatio: sandbox.stub() };
@@ -180,6 +180,7 @@ describe('Module - Core', () => {
       assets,
       fragments: [{
         name: 'test',
+        gateway: 'test',
         clientAsync: true
       }],
       page: 'page'
@@ -217,6 +218,7 @@ describe('Module - Core', () => {
       assets,
       fragments: [{
         name: 'test',
+        gateway: 'test',
         attributes: {
           if: "false"
         },
@@ -272,6 +274,7 @@ describe('Module - Core', () => {
       assets,
       fragments: [{
         name: 'test',
+        gateway: 'test',
         attributes: {
           if: "false"
         },
@@ -285,7 +288,7 @@ describe('Module - Core', () => {
       }],
       page: 'page',
       peers: [],
-      intersectionObserverOptions: { 
+      intersectionObserverOptions: {
         rootMargin:"500px"
       }
     } as IPageLibConfiguration;
@@ -330,6 +333,7 @@ describe('Module - Core', () => {
       assets,
       fragments: [{
         name: 'test',
+        gateway: 'test',
         attributes: {
           if: "false"
         },
@@ -386,6 +390,7 @@ describe('Module - Core', () => {
       assets,
       fragments: [{
         name: 'test',
+        gateway: 'test',
         attributes: {
           if: "false",
           withoutPathname: "true"
@@ -466,6 +471,7 @@ describe('Module - Core', () => {
       assets,
       fragments: [{
         name: 'test',
+        gateway: 'test',
         attributes: {
           if: "false"
         },

--- a/test/util.spec.ts
+++ b/test/util.spec.ts
@@ -8,6 +8,7 @@ import * as faker from "faker";
 declare global {
     interface Window {
         PuzzleJs: PuzzleJs;
+        console: any;
     }
 }
 


### PR DESCRIPTION
# Summary

## Background

One page can hold one fragment with the same name regardless of its gateway name. This makes it hard to implement a progressive switch from one gateway to another.

## Implementation

The core will send gateway info for both fragments and assets to load the specific one without complications. This change should not break any existing core since we only make this query if we can find existing gateway information. Everything should work as is if there is no update about supplying gateway information.

## Next Step

The core will be updated to supply the necessary information and other necessary changes.