### PR TITLE
Improve render async fragment util

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@puzzle-js/client-lib",
   "main": "dist/index.js",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "author": "<emre.kul@trendyol.com>",
   "license": "MIT",
   "repository": {

--- a/src/core.ts
+++ b/src/core.ts
@@ -326,11 +326,12 @@ export class Core extends Module {
     });
   }
 
-  static renderAsyncFragment(fragmentName: string, gatewayName?: string) {
+  static renderAsyncFragment(fragmentName: string) {
     const fragment = this.__pageConfiguration.fragments.find(
       _fragment => _fragment.name === fragmentName &&
-        ((_fragment.gateway && gatewayName) ? _fragment.gateway === gatewayName : true)
+        ((typeof _fragment.attributes.if === "string") ? _fragment.attributes.if === "true" : true)
     );
+
     if (fragment) {
       const selector = this.getFragmentContainerSelector(fragment, "main");
       const fragmentContainer = window.document.querySelector(selector);


### PR DESCRIPTION
# Summary

## Background

In the most recent revisions, https://github.com/puzzle-js/puzzle-lib/pull/57, we enhanced our gateway queries. Although there is one public function—the "renderAsyncFragment" function—we use it for on-demand fragments. To further tune fragment queries, we added the option to specify an optional gateway name. However, this circumstance only happens if a page has two fragments with the same name. I, therefore, see a chance to streamline API by simply confirming the existence of the if attribute and its value.